### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ Shell script linter plugin for Buildkite
 
 [![Build status](https://badge.buildkite.com/c00862681e75d87436590fe047fab7ef179142ebdacd3c40c0.svg?branch=master)](https://buildkite.com/operable/shellcheck-buildkite-plugin)
 
-**NOTE: Plugins only work with the as yet unlreleased 3.0 version of the Buildkite Agent!**
-
 **NOTE: This plugin is a work-in-progress. We use it internally at Operable to test our bundles. However, it may still blow up your systems; use at your own discretion!**
 
 This plugin allows you to lint your shell scripts using [shellcheck](https://github.com/koalaman/shellcheck). It is implememnted in terms of the Docker image for `shellcheck`, so it must be run on a build agent that has access to `docker`.
@@ -38,22 +36,22 @@ Codes for the warnings can be found in the [shellcheck wiki](https://github.com/
 - steps
   - label: Simple linting
     plugins:
-      operable/shellcheck:
-        script: my_script.sh
+      - operable/shellcheck:
+          script: my_script.sh
 
   - label: Lint multiple scripts
     plugins:
-      operable/shellcheck:
-        script:
-          - my_script.sh
-          - my_other_script.sh
-          - yet_another_script.sh
+      - operable/shellcheck:
+          script:
+            - my_script.sh
+            - my_other_script.sh
+            - yet_another_script.sh
 
   - label: Exclude some warnings
     plugins:
-      operable/shellcheck:
-        script: my_script.sh
-        opts: --exclude=1000
+      - operable/shellcheck:
+          script: my_script.sh
+          opts: --exclude=1000
 ```
 
 Also see this plugin's [pipeline configuration](.buildkite/pipeline.sh) for other examples.


### PR DESCRIPTION
Hi again Operable team 😊

(This is the same as https://github.com/operable/cog-bundle-buildkite-plugin/pull/5, but I'm not sure which one you'll get to first, so here's all the info again!)

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks. I also removed the note about the unreleased Agent, as v3 has been out for a while now 😊

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.